### PR TITLE
New feature: show_skipped parameter

### DIFF
--- a/plan/config.go
+++ b/plan/config.go
@@ -36,6 +36,7 @@ type WorkspaceConfig struct {
 	Branch           string        `yaml:"branch"`
 	Policy           policy.Policy `yaml:"policy"`
 	Comment          string        `yaml:"comment"`
+	ShowSkipped      bool          `yaml:"show_skipped"`
 }
 
 type Comment struct {

--- a/plan/context.go
+++ b/plan/context.go
@@ -90,7 +90,7 @@ func (pc *Context) Evaluate() Result {
 		return Result{Error: err}
 	}
 	if !ok {
-		return Result{Status: StatusSkipped}
+		return Result{Status: StatusSkipped, Description: "Run not triggered"}
 	}
 
 	polRes := pc.evaluator.Evaluate(pc.ctx, pc.prctx)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -214,7 +214,10 @@ func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, reques
 	switch result.Status {
 	case plan.StatusSkipped:
 		logger.Debug().Msgf("Workspace %s skipped", wkcfg)
-		return nil
+		if !wkcfg.ShowSkipped {
+			return nil
+		}
+		statusState = "success"
 	case plan.StatusPolicyPending:
 		statusState = "pending"
 	case plan.StatusPolicyDisapproved:


### PR DESCRIPTION
When the `show_skipped` parameter is set to true on a workspace config, a status check will be created even when the workspace gets skipped.