### PR TITLE
Check that the workspace does not have speculative plans enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/h2non/filetype v1.1.0 // indirect
-	github.com/hashicorp/go-tfe v0.10.1
+	github.com/hashicorp/go-tfe v0.10.2
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f // indirect
 	github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd // indirect
 	github.com/palantir/go-baseapp v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-tfe v0.10.1 h1:Fz3xnYY/iQ5BQToqYXNZ9qSobuOSElbVe+zHKgzbfdw=
 github.com/hashicorp/go-tfe v0.10.1/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
+github.com/hashicorp/go-tfe v0.10.2 h1:nYYlk0B0ku9cyuU9JHvpVd21whpwWfGiRf05VV9jdAY=
+github.com/hashicorp/go-tfe v0.10.2/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=

--- a/plan/context.go
+++ b/plan/context.go
@@ -347,6 +347,10 @@ func (pc *Context) validate(wk *tfe.Workspace) error {
 			pc.wkcfg.WorkingDirectory, wk.WorkingDirectory)
 	}
 
+	if wk.SpeculativeEnabled {
+		return errors.New("workspace has speculative plans enabled")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a check for the `speculative_enabled` property of the TFE workspace during policy evaluation.
If `speculative_enabled` is not set to `false`, the status check will be an error.