### PR TITLE
Update policy-bot to v1.20.0

### DIFF
--- a/config/plan-examples/tfe-plan.yml
+++ b/config/plan-examples/tfe-plan.yml
@@ -13,6 +13,7 @@ workspaces:
 
 approval_rules:
   - name: lgtm
+    description: Approvers commented LGTM
     options:
       invalidate_on_push: true
       request_review:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd // indirect
 	github.com/palantir/go-baseapp v0.2.1
 	github.com/palantir/go-githubapp v0.5.1
-	github.com/palantir/policy-bot v1.19.2
+	github.com/palantir/policy-bot v1.20.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.20.0
 	github.com/shurcooL/githubv4 v0.0.0-20200915023059-bc5e4feb2971

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/palantir/go-githubapp v0.5.0 h1:mAdLgaaNV0zrqSv1q0zpJbKq65H92uIrAlSwR
 github.com/palantir/go-githubapp v0.5.0/go.mod h1:/Xm5h66uEBX24An2Ln8H6Rk44z8uwk4E6m4gNrPadjQ=
 github.com/palantir/go-githubapp v0.5.1 h1:KwcbWsAkFHVuo7oa0f4LSYqVpYo0mFRsYoD3MbzPmXM=
 github.com/palantir/go-githubapp v0.5.1/go.mod h1:/Xm5h66uEBX24An2Ln8H6Rk44z8uwk4E6m4gNrPadjQ=
-github.com/palantir/policy-bot v1.19.2 h1:leckEmmHTpoLeZmKs24DbeH+kW1OErx3RcBCGQuTn6o=
-github.com/palantir/policy-bot v1.19.2/go.mod h1:b2kT6HrvEtazyK/WiXM8F38ul1ug0/NIh+ofPbBFUWw=
+github.com/palantir/policy-bot v1.20.0 h1:MN/ddgdtIiD0Pql1koPbeY5gHkoXDpUO6sGkVSB41U0=
+github.com/palantir/policy-bot v1.20.0/go.mod h1:b2kT6HrvEtazyK/WiXM8F38ul1ug0/NIh+ofPbBFUWw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/plan/context.go
+++ b/plan/context.go
@@ -82,6 +82,10 @@ func NewContext(ctx context.Context, wkcfg WorkspaceConfig, prctx pull.Context, 
 	}, nil
 }
 
+func (pc *Context) Trigger() common.Trigger {
+	return pc.evaluator.Trigger()
+}
+
 func (pc *Context) Evaluate() Result {
 	logger := zerolog.Ctx(pc.ctx)
 
@@ -90,7 +94,7 @@ func (pc *Context) Evaluate() Result {
 		return Result{Error: err}
 	}
 	if !ok {
-		return Result{Status: StatusSkipped, Description: "Run not triggered"}
+		return Result{Status: StatusSkipped, StatusDescription: "Run not triggered"}
 	}
 
 	polRes := pc.evaluator.Evaluate(pc.ctx, pc.prctx)
@@ -106,9 +110,9 @@ func (pc *Context) Evaluate() Result {
 	case common.StatusSkipped:
 		return Result{Error: errors.New("all policy rules were skipped")}
 	case common.StatusPending:
-		return Result{Status: StatusPolicyPending, Description: polRes.Description, PolicyResult: polRes}
+		return Result{Status: StatusPolicyPending, StatusDescription: polRes.StatusDescription, PolicyResult: polRes}
 	case common.StatusDisapproved:
-		return Result{Status: StatusPolicyDisapproved, Description: polRes.Description, PolicyResult: polRes}
+		return Result{Status: StatusPolicyDisapproved, StatusDescription: polRes.StatusDescription, PolicyResult: polRes}
 	default:
 		return Result{Error: errors.Errorf("policy evaluation resulted in unexpected state: %s", polRes.Status)}
 	}
@@ -174,10 +178,10 @@ func (pc *Context) Evaluate() Result {
 
 	logger.Debug().Msgf("Speculative plan created with ID %s", run.ID)
 	return Result{
-		Status:       StatusPlanCreated,
-		Description:  "Terraform plan: pending",
-		PolicyResult: polRes,
-		RunID:        run.ID,
+		Status:            StatusPlanCreated,
+		StatusDescription: "Terraform plan: pending",
+		PolicyResult:      polRes,
+		RunID:             run.ID,
 	}
 }
 

--- a/plan/result.go
+++ b/plan/result.go
@@ -46,8 +46,8 @@ func (s EvaluationStatus) String() string {
 }
 
 type Result struct {
-	Description string
-	Status      EvaluationStatus
+	StatusDescription string
+	Status            EvaluationStatus
 
 	Error error
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -127,7 +127,7 @@ func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *g
 	return ctx, logger
 }
 
-func (b *Base) Evaluate(ctx context.Context, installationID int64, requestReviews bool, loc pull.Locator) error {
+func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger common.Trigger, loc pull.Locator) error {
 	client, err := b.NewInstallationClient(installationID)
 	if err != nil {
 		return err
@@ -149,10 +149,10 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, requestReview
 		return errors.WithMessage(err, fmt.Sprintf("failed to fetch policy: %s", fetchedConfig))
 	}
 
-	return b.EvaluateFetchedConfig(ctx, prctx, requestReviews, client, fetchedConfig)
+	return b.EvaluateFetchedConfig(ctx, prctx, client, fetchedConfig, trigger)
 }
 
-func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, requestReviews bool, client *github.Client, fetchedConfig FetchedConfig) error {
+func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, fetchedConfig FetchedConfig, trigger common.Trigger) error {
 	logger := zerolog.Ctx(ctx)
 
 	if fetchedConfig.Missing() {
@@ -175,7 +175,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, re
 		go func() {
 			defer wg.Done()
 
-			if err := b.EvaluateWorkspace(ctx, prctx, requestReviews, client, fetchedConfig, wkcfg); err != nil {
+			if err := b.EvaluateWorkspace(ctx, prctx, client, fetchedConfig, trigger, wkcfg); err != nil {
 				atomic.AddUint32(&evaluationFailures, 1)
 				logger.Error().Err(err).Msgf("Failed to evaluate workspace %s", wkcfg)
 			}
@@ -191,7 +191,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, re
 	return errors.Errorf("failed to evaluate %d workspaces", evaluationFailures)
 }
 
-func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, requestReviews bool, client *github.Client, fetchedConfig FetchedConfig, wkcfg plan.WorkspaceConfig) error {
+func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, client *github.Client, fetchedConfig FetchedConfig, trigger common.Trigger, wkcfg plan.WorkspaceConfig) error {
 	logger := zerolog.Ctx(ctx)
 
 	pc, err := plan.NewContext(ctx, wkcfg, prctx, fetchedConfig.Config, b.statusCheckContext(wkcfg), client, b.TFEClientProvider)
@@ -202,6 +202,15 @@ func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, reques
 		return err
 	}
 
+	policyTrigger := pc.Trigger()
+	if !trigger.Matches(policyTrigger) {
+		logger.Debug().
+			Str("event_trigger", trigger.String()).
+			Str("policy_trigger", policyTrigger.String()).
+			Msg("No evaluation necessary for this trigger, skipping")
+		return nil
+	}
+
 	result := pc.Evaluate()
 	if result.Error != nil {
 		statusMessage := fmt.Sprintf("Error evaluating workspace %s defined by %s", wkcfg, fetchedConfig)
@@ -210,7 +219,7 @@ func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, reques
 		return err
 	}
 
-	statusDescription := result.Description
+	statusDescription := result.StatusDescription
 	var statusState string
 	var runID string
 	switch result.Status {
@@ -240,12 +249,11 @@ func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, reques
 		return errors.Errorf("evaluation resulted in unexpected state: %s", result.Status)
 	}
 
-	err = b.PostStatus(ctx, prctx, wkcfg, runID, client, statusState, statusDescription)
-	if err != nil {
+	if err := b.PostStatus(ctx, prctx, wkcfg, runID, client, statusState, statusDescription); err != nil {
 		return err
 	}
 
-	if requestReviews && result.Status == plan.StatusPolicyPending && !prctx.IsDraft() {
+	if result.Status == plan.StatusPolicyPending && !prctx.IsDraft() {
 		if reqs := reviewer.FindRequests(&result.PolicyResult); len(reqs) > 0 {
 			logger.Debug().Msgf("Found %d pending rules with review requests enabled", len(reqs))
 			return b.requestReviews(ctx, prctx, client, reqs)
@@ -257,47 +265,73 @@ func (b *Base) EvaluateWorkspace(ctx context.Context, prctx pull.Context, reques
 }
 
 func (b *Base) requestReviews(ctx context.Context, prctx pull.Context, client *github.Client, reqs []*common.Result) error {
+	const maxDelayMillis = 2500
+
 	logger := zerolog.Ctx(ctx)
 
-	hasReviewers, err := prctx.HasReviewers()
-	if err != nil {
-		return errors.Wrap(err, "failed to check existing reviewers")
-	}
-	if hasReviewers {
-		logger.Debug().Msg("PR has existing reviewers, skipping reviewer assignment")
-		return nil
-	}
-
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	requestedUsers, requestedTeams, err := reviewer.SelectReviewers(ctx, prctx, reqs, r)
+	// Seed the random source with the PR creation time so that repeated
+	// evaluations produce the same set of reviewers. This is required to avoid
+	// duplicate requests on later evaluations.
+	r := rand.New(rand.NewSource(prctx.CreatedAt().UnixNano()))
+	selection, err := reviewer.SelectReviewers(ctx, prctx, reqs, r)
 	if err != nil {
 		return errors.Wrap(err, "failed to select reviewers")
 	}
 
+	if selection.IsEmpty() {
+		logger.Debug().Msg("No eligible users or teams found for review")
+		return nil
+	}
+
+	// This is a terrible strategy to avoid conflicts between closely spaced
+	// events assigning the same reviewers, but I expect it to work alright in
+	// practice and it avoids any kind of coordination backend:
+	//
+	// Wait a random amount of time to space out events then check for existing
+	// reviewers and apply the difference. The idea is to order two competing
+	// events such that one observes the applied reviewers of the other.
+	//
+	// Use the global random source instead of the per-PR source so that two
+	// events for the same PR don't wait for the same amount of time.
+	delay := time.Duration(rand.Intn(maxDelayMillis)) * time.Millisecond
+	logger.Debug().Msgf("Waiting for %s to spread out reviewer processing", delay)
+	time.Sleep(delay)
+
 	// check again if someone assigned a reviewer while we were calculating users to request
-	hasReviewersAfter, err := prctx.HasReviewers()
+	reviewers, err := prctx.RequestedReviewers()
 	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to double-check existing reviewers, assuming there are still no reviewers")
-		hasReviewersAfter = false
+		return err
 	}
 
-	if (len(requestedUsers) > 0 || len(requestedTeams) > 0) && !hasReviewersAfter {
-		reviewers := github.ReviewersRequest{
-			Reviewers:     requestedUsers,
-			TeamReviewers: requestedTeams,
-		}
-
+	if diff := selection.Difference(reviewers); !diff.IsEmpty() {
+		req := selectionToReviewersRequest(diff)
 		logger.Debug().
-			Strs("users", requestedUsers).
-			Strs("teams", requestedTeams).
-			Msgf("Requesting reviews from %d users and %d teams", len(requestedUsers), len(requestedTeams))
+			Strs("users", req.Reviewers).
+			Strs("teams", req.TeamReviewers).
+			Msgf("Requesting reviews from %d users and %d teams", len(req.Reviewers), len(req.TeamReviewers))
 
-		_, _, err = client.PullRequests.RequestReviewers(ctx, prctx.RepositoryOwner(), prctx.RepositoryName(), prctx.Number(), reviewers)
-		if err != nil {
-			return errors.Wrap(err, "failed to request reviewers")
-		}
-	} else {
-		logger.Debug().Msg("No eligible users or teams found for review, or reviewers were assigned during processing")
+		_, _, err = client.PullRequests.RequestReviewers(ctx, prctx.RepositoryOwner(), prctx.RepositoryName(), prctx.Number(), req)
+		return errors.Wrap(err, "failed to request reviewers")
 	}
+
+	logger.Debug().Msg("All selected reviewers are already assigned or were explicitly removed")
 	return nil
+}
+
+func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
+	req := github.ReviewersRequest{}
+
+	if len(s.Users) > 0 {
+		req.Reviewers = s.Users
+	} else {
+		req.Reviewers = []string{}
+	}
+
+	if len(s.Teams) > 0 {
+		req.TeamReviewers = s.Teams
+	} else {
+		req.TeamReviewers = []string{}
+	}
+
+	return req
 }

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-github/v32/github"
 	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/pkg/errors"
 
 	"github.com/G-Research/tfe-plan-bot/pull"
@@ -56,7 +57,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		// of the event, but I can't find confirmation of that in the GitHub
 		// docs. The PR object is a minimal version that is missing the "state"
 		// field, so we can't check without loading the full object.
-		if err := h.Evaluate(ctx, installationID, false, pull.Locator{
+		if err := h.Evaluate(ctx, installationID, common.TriggerStatus, pull.Locator{
 			Owner:  ownerName,
 			Repo:   repoName,
 			Number: pr.GetNumber(),

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/palantir/policy-bot/policy/approval"
+	"github.com/palantir/policy-bot/policy/common"
 
 	"github.com/G-Research/tfe-plan-bot/plan"
 	"github.com/G-Research/tfe-plan-bot/pull"
@@ -97,7 +98,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		logger.Warn().Str(LogKeyAudit, "issue_comment").Msg("Skipped tampering check because the policy is not valid")
 	}
 
-	return h.EvaluateFetchedConfig(ctx, prctx, false, client, fetchedConfig)
+	return h.EvaluateFetchedConfig(ctx, prctx, client, fetchedConfig, common.TriggerComment)
 }
 
 func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Context, client *github.Client, event github.IssueCommentEvent, config *plan.Config) bool {

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-github/v32/github"
 	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/pkg/errors"
 
 	"github.com/G-Research/tfe-plan-bot/pull"
@@ -43,7 +44,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
-	return h.Evaluate(ctx, installationID, false, pull.Locator{
+	return h.Evaluate(ctx, installationID, common.TriggerReview, pull.Locator{
 		Owner:  event.GetRepo().GetOwner().GetLogin(),
 		Repo:   event.GetRepo().GetName(),
 		Number: event.GetPullRequest().GetNumber(),

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-github/v32/github"
 	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/pkg/errors"
 
 	"github.com/G-Research/tfe-plan-bot/pull"
@@ -132,7 +133,7 @@ func (h *Status) processOthers(ctx context.Context, event github.StatusEvent) er
 	evaluationFailures := 0
 	for _, pr := range prs {
 		if pr.GetState() == "open" {
-			err = h.Evaluate(ctx, installationID, false, pull.Locator{
+			err = h.Evaluate(ctx, installationID, common.TriggerStatus, pull.Locator{
 				Owner:  ownerName,
 				Repo:   repoName,
 				Number: pr.GetNumber(),


### PR DESCRIPTION
This PR updates policy-bot to v1.20.0, bringing the following changes:

* Add optional description field to approval rules
* Use triggers to control evaluation, which let us skip processing for
  policies that don't actually change based on events
* Run reviewer assignment on all evaluations