### PR TITLE
CI: Enable dependabot [PART I]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## PART I

### This PR is part of a series of changes aimed at enhancing the CI processes and improving the maturity score of the `tfe-plan-bot` project.

 - PART I - https://github.com/G-Research/tfe-plan-bot/pull/33
 - PART II - https://github.com/G-Research/tfe-plan-bot/pull/34
 - PART III - https://github.com/G-Research/tfe-plan-bot/pull/35
 - PART IV - https://github.com/G-Research/tfe-plan-bot/pull/36

__Please review and merge them in following order__

__________

### Scope of this PR is:

 - enable dependabot for `go` packages and github actions


Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/316
