### PR TITLE
Add nil check to files found in matchPR func

### DIFF
--- a/plan/context.go
+++ b/plan/context.go
@@ -281,6 +281,10 @@ func (pc *Context) matchPR() (bool, error) {
 
 	doFilesMatchDirectory := func(changedFiles []*policy_pull.File, dir string) bool {
 		for _, file := range changedFiles {
+			if file == nil {
+				fmt.Printf("File: %s is nil\n", file)
+				continue
+			} 
 			if strings.HasPrefix(file.Filename, dir+"/") {
 				return true
 			}

--- a/plan/context.go
+++ b/plan/context.go
@@ -281,10 +281,7 @@ func (pc *Context) matchPR() (bool, error) {
 
 	doFilesMatchDirectory := func(changedFiles []*policy_pull.File, dir string) bool {
 		for _, file := range changedFiles {
-			if file == nil {
-				continue
-			} 
-			if strings.HasPrefix(file.Filename, dir+"/") {
+			if file != nil && strings.HasPrefix(file.Filename, dir+"/") {
 				return true
 			}
 		}

--- a/plan/context.go
+++ b/plan/context.go
@@ -282,7 +282,6 @@ func (pc *Context) matchPR() (bool, error) {
 	doFilesMatchDirectory := func(changedFiles []*policy_pull.File, dir string) bool {
 		for _, file := range changedFiles {
 			if file == nil {
-				fmt.Printf("File: %s is nil\n", file)
 				continue
 			} 
 			if strings.HasPrefix(file.Filename, dir+"/") {

--- a/plan/context_test.go
+++ b/plan/context_test.go
@@ -380,6 +380,27 @@ func TestMatchPR(t *testing.T) {
 			false,
 			errors.New("oops"),
 		},
+		{
+			"nil slices in file list",
+			"test",
+			[]string{},
+			true, 
+			MockPullContext{
+				defaultBranch: "test_branch",
+				changedFiles: []*pull.File{
+					{
+						Filename:  "alpha/file.go",
+						Status:    0,
+						Additions: 5,
+						Deletions: 5,
+					},
+					nil,
+				},
+			},
+			"main",
+			false,
+			nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix edge case with nils in files changed

`"panic: runtime error: invalid memory address or nil pointer dereference[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x99ef25]goroutine 111667 [running]:github.com/G-Research/tfe-plan-bot/plan.(*Context).matchPR.func1(...)\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/plan/context.go:284github.com/G-Research/tfe-plan-bot/plan.(*Context).matchPR(0xc0009d8a50)\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/plan/context.go:310 +0x1c5github.com/G-Research/tfe-plan-bot/plan.(*Context).Evaluate(_)\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/plan/context.go:95 +0x7agithub.com/G-Research/tfe-plan-bot/server/handler.(*Base).EvaluateWorkspace(0xc000180230, {0xc566f0, 0xc002c09d10}, {0xc5e558, _}, _, {{0xc00090efa0, 0x6}, {0xc00090ef90, 0xd}, ...}, ...)\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/server/handler/base.go:216 +0x3bfgithub.com/G-Research/tfe-plan-bot/server/handler.(*Base).EvaluateFetchedConfig.func1()\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/server/handler/base.go:180 +0x11ecreated by github.com/G-Research/tfe-plan-bot/server/handler.(*Base).EvaluateFetchedConfig in goroutine 100\t/home/runner/work/tfe-plan-bot/tfe-plan-bot/server/handler/base.go:177 +0x2b6"`