### PR TITLE
Nil ptr fix if TFE workspace VCS not enabled

### DIFF
--- a/plan/context.go
+++ b/plan/context.go
@@ -354,14 +354,18 @@ func (pc *Context) postCommentIfNeeded() {
 }
 
 func (pc *Context) validate(wk *tfe.Workspace) error {
-	wkBranch := wk.VCSRepo.Branch
+	var wkBranch string
+	if wk.VCSRepo != nil {
+		wkBranch = wk.VCSRepo.Branch
+	}
+
 	if wkBranch == "" {
 		wkBranch = pc.prctx.DefaultBranch()
 	}
 
 	if pc.branch() != wkBranch {
 		return errors.Errorf("workspace branch mismatch: config=%q tfe=%q",
-			pc.wkcfg.Branch, wk.VCSRepo.Branch)
+			pc.wkcfg.Branch, wkBranch)
 	}
 
 	if pc.workingDirectory() != path.Clean(wk.WorkingDirectory) {


### PR DESCRIPTION
Not sure if this changes the validation logic to be invalid, ask was to allow planbot to not error out when VCS Integration is disabled for few but not all workspaces in a git repo