### PR TITLE
Optimize GitHub API calls by pre-fetching changed files before workspace evaluation                                       

### DIFF
--- a/plan/filter.go
+++ b/plan/filter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 G-Research Limited
+// Copyright 2026 G-Research Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/plan/filter.go
+++ b/plan/filter.go
@@ -1,0 +1,87 @@
+// Copyright 2020 G-Research Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"path"
+	"strings"
+
+	"github.com/palantir/policy-bot/pull"
+)
+
+// FilterRelevantWorkspaces returns only the workspaces whose branch and file
+// paths match the pull request, avoiding unnecessary evaluation of workspaces
+// that would be skipped by matchPR. This allows callers to pre-filter before
+// spawning concurrent evaluations.
+func FilterRelevantWorkspaces(cfg *Config, baseBranch string, defaultBranch string, changedFiles []*pull.File) []WorkspaceConfig {
+	relevant := make([]WorkspaceConfig, 0, len(cfg.Workspaces))
+
+	for _, wkcfg := range cfg.Workspaces {
+		// Determine expected branch
+		branch := wkcfg.Branch
+		if branch == "" {
+			branch = defaultBranch
+		}
+
+		// Skip if PR doesn't target this workspace's branch
+		if baseBranch != branch {
+			continue
+		}
+
+		// Check if changed files match trigger prefixes
+		if !wkcfg.SkipTriggerPrefixes {
+			if FilesMatchAnyDirectory(changedFiles, cfg.TriggerPrefixes) {
+				relevant = append(relevant, wkcfg)
+				continue
+			}
+		}
+
+		// Check working directory
+		workingDir := path.Clean(wkcfg.WorkingDirectory)
+		if workingDir == "." {
+			relevant = append(relevant, wkcfg)
+			continue
+		}
+
+		if FilesMatchDirectory(changedFiles, workingDir) {
+			relevant = append(relevant, wkcfg)
+		}
+	}
+
+	return relevant
+}
+
+// FilesMatchDirectory returns true if any of the given files have a path
+// prefixed by dir + "/".
+func FilesMatchDirectory(files []*pull.File, dir string) bool {
+	prefix := dir + "/"
+	for _, file := range files {
+		if file != nil && strings.HasPrefix(file.Filename, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilesMatchAnyDirectory returns true if any file matches any of the given
+// directories.
+func FilesMatchAnyDirectory(files []*pull.File, dirs []string) bool {
+	for _, dir := range dirs {
+		if FilesMatchDirectory(files, dir) {
+			return true
+		}
+	}
+	return false
+}

--- a/plan/filter_test.go
+++ b/plan/filter_test.go
@@ -1,0 +1,175 @@
+package plan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/palantir/policy-bot/pull"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilesMatchDirectory(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []*pull.File
+		dir   string
+		want  bool
+	}{
+		{
+			name:  "match",
+			files: []*pull.File{{Filename: "infra/main.tf"}},
+			dir:   "infra",
+			want:  true,
+		},
+		{
+			name:  "no match",
+			files: []*pull.File{{Filename: "src/app.go"}},
+			dir:   "infra",
+			want:  false,
+		},
+		{
+			name:  "prefix but not directory boundary",
+			files: []*pull.File{{Filename: "infrastructure/main.tf"}},
+			dir:   "infra",
+			want:  false,
+		},
+		{
+			name:  "empty files",
+			files: []*pull.File{},
+			dir:   "infra",
+			want:  false,
+		},
+		{
+			name:  "nil file in list",
+			files: []*pull.File{nil, {Filename: "infra/main.tf"}},
+			dir:   "infra",
+			want:  true,
+		},
+		{
+			name:  "nested directory match",
+			files: []*pull.File{{Filename: "modules/networking/vpc.tf"}},
+			dir:   "modules/networking",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilesMatchDirectory(tt.files, tt.dir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilesMatchAnyDirectory(t *testing.T) {
+	files := []*pull.File{
+		{Filename: "modules/networking/vpc.tf"},
+	}
+
+	assert.True(t, FilesMatchAnyDirectory(files, []string{"other", "modules/networking"}))
+	assert.False(t, FilesMatchAnyDirectory(files, []string{"infra", "src"}))
+	assert.False(t, FilesMatchAnyDirectory(files, []string{}))
+}
+
+func TestFilterRelevantWorkspaces(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cfg            *Config
+		baseBranch     string
+		defaultBranch  string
+		changedFiles   []*pull.File
+		expectedNames  []string
+	}{
+		{
+			name: "filters by branch, working dir, and trigger prefixes",
+			cfg: &Config{
+				TriggerPrefixes: []string{"modules/common"},
+				Workspaces: []WorkspaceConfig{
+					{Organization: "org", Name: "ws-infra", WorkingDirectory: "infra", Branch: "main"},
+					{Organization: "org", Name: "ws-app", WorkingDirectory: "app", Branch: "main"},
+					{Organization: "org", Name: "ws-wrong-branch", WorkingDirectory: "infra", Branch: "develop"},
+					{Organization: "org", Name: "ws-root", WorkingDirectory: ".", Branch: "main"},
+					{Organization: "org", Name: "ws-skip-triggers", WorkingDirectory: "other", Branch: "main", SkipTriggerPrefixes: true},
+				},
+			},
+			baseBranch:    "main",
+			defaultBranch: "main",
+			changedFiles: []*pull.File{
+				{Filename: "infra/main.tf"},
+				{Filename: "modules/common/variables.tf"},
+			},
+			expectedNames: []string{"ws-infra", "ws-app", "ws-root"},
+		},
+		{
+			name: "uses default branch when workspace branch is empty",
+			cfg: &Config{
+				Workspaces: []WorkspaceConfig{
+					{Organization: "org", Name: "ws-default", WorkingDirectory: "infra", Branch: ""},
+				},
+			},
+			baseBranch:    "main",
+			defaultBranch: "main",
+			changedFiles: []*pull.File{
+				{Filename: "infra/main.tf"},
+			},
+			expectedNames: []string{"ws-default"},
+		},
+		{
+			name: "no workspaces match",
+			cfg: &Config{
+				Workspaces: []WorkspaceConfig{
+					{Organization: "org", Name: "ws-infra", WorkingDirectory: "infra", Branch: "main"},
+				},
+			},
+			baseBranch:    "main",
+			defaultBranch: "main",
+			changedFiles: []*pull.File{
+				{Filename: "docs/readme.md"},
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "all workspaces on wrong branch",
+			cfg: &Config{
+				Workspaces: []WorkspaceConfig{
+					{Organization: "org", Name: "ws1", WorkingDirectory: "infra", Branch: "release"},
+					{Organization: "org", Name: "ws2", WorkingDirectory: "app", Branch: "release"},
+				},
+			},
+			baseBranch:    "main",
+			defaultBranch: "main",
+			changedFiles: []*pull.File{
+				{Filename: "infra/main.tf"},
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "working directory dot matches all files",
+			cfg: &Config{
+				Workspaces: []WorkspaceConfig{
+					{Organization: "org", Name: "ws-root", WorkingDirectory: ".", Branch: "main"},
+					{Organization: "org", Name: "ws-root-empty", WorkingDirectory: "", Branch: "main"},
+				},
+			},
+			baseBranch:    "main",
+			defaultBranch: "main",
+			changedFiles: []*pull.File{
+				{Filename: "anything/at/all.txt"},
+			},
+			expectedNames: []string{"ws-root", "ws-root-empty"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Test Case: %s", tc.name), func(t *testing.T) {
+			result := FilterRelevantWorkspaces(tc.cfg, tc.baseBranch, tc.defaultBranch, tc.changedFiles)
+
+			resultNames := make([]string, len(result))
+			for i, ws := range result {
+				resultNames[i] = ws.Name
+			}
+
+			assert.ElementsMatch(t, tc.expectedNames, resultNames)
+		})
+	}
+}

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -167,10 +167,28 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 		return nil
 	}
 
+	// Pre-fetch changed files once before fanning out to workspace goroutines.
+	// The pull.Context is not thread-safe, so this ensures a single API call
+	// to GET /repos/:owner/:repo/pulls/:number/files and populates the cache
+	// before concurrent access.
+	changedFiles, err := prctx.ChangedFiles()
+	if err != nil {
+		return errors.Wrap(err, "failed to list pull request files")
+	}
+
+	// Pre-filter workspaces: skip those whose working directory and trigger
+	// prefixes don't match the changed files. This avoids unnecessary TFE API
+	// calls and goroutine overhead for irrelevant workspaces.
+	baseBranch, _ := prctx.Branches()
+	relevantWorkspaces := plan.FilterRelevantWorkspaces(fetchedConfig.Config, baseBranch, prctx.DefaultBranch(), changedFiles)
+
+	logger.Debug().Msgf("Filtered %d/%d workspaces as relevant based on changed files",
+		len(relevantWorkspaces), len(fetchedConfig.Config.Workspaces))
+
 	var wg sync.WaitGroup
 	var evaluationFailures uint32
-	for i := range fetchedConfig.Config.Workspaces {
-		wkcfg := fetchedConfig.Config.Workspaces[i]
+	for i := range relevantWorkspaces {
+		wkcfg := relevantWorkspaces[i]
 
 		wg.Add(1)
 
@@ -337,3 +355,4 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 
 	return req
 }
+


### PR DESCRIPTION
  - Pre-fetch pull request changed files (GET /repos/:owner/:repo/pulls/:number/files) once before fanning out to concurrent workspace evaluations, eliminating duplicate API calls caused by the non-thread-safe pull.Context cache being accessed concurrently
  - Pre-filter workspaces by branch and changed file paths before spawning goroutines, skipping unnecessary TFE API calls (workspace reads, config version uploads, speculative plans) for workspaces that can't possibly match